### PR TITLE
Only require activerecord-import for Rails < 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ User.to_df # => Daru::DataFrame is returned
 ### Daru::DataFrame#write_model
 
 For each row, call `to_h` and pass it to `model.new`.
-And then, imports them using `model.import`.
+And then, imports them using `model.insert_all` on Rails >= 6, or `model.import` (requires adding
+`activerecord-import` to your `Gemfile`).
 
 ```ruby
 df.write_model(User)

--- a/jupyter_on_rails.gemspec
+++ b/jupyter_on_rails.gemspec
@@ -45,6 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'iruby'
   spec.add_dependency 'railties'
 
-  spec.add_dependency 'activerecord-import'
   spec.add_dependency 'daru'
 end

--- a/lib/jupyter_on_rails/daru/data_frame_ext.rb
+++ b/lib/jupyter_on_rails/daru/data_frame_ext.rb
@@ -2,10 +2,28 @@ module JupyterOnRails
   module Daru
     module DataFrameExt
       def write_model(model)
-        require 'activerecord-import'
+        if ActiveRecord.version >= Gem::Version.new('6.0.0.beta1')
+          write_model_rails(model)
+        else
+          write_model_activerecord_import(model)
+        end
+      end
 
-        objs = map_rows(&:to_h).map(&model.method(:new))
-        model.import(objs)
+      private
+
+      def write_model_activerecord_import(model)
+        begin
+          require 'activerecord-import'
+        rescue LoadError
+          raise 'write_model requires either Rails >= 6 or the activerecord-import gem'
+        end
+
+        records = map_rows(&:to_h).map(&model.method(:new))
+        model.import(records)
+      end
+
+      def write_model_rails(model)
+        model.insert_all(map_rows(&:to_h))
       end
     end
   end


### PR DESCRIPTION
Rails 6 and above have a built-in [`insert_all`](https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-insert_all) method.