### PR TITLE
Follow deprecation hint and favor environment variable JUPYTER_DATA_DIR over --ipython-dir flag

### DIFF
--- a/lib/jupyter_on_rails/railtie/jupyter.rake
+++ b/lib/jupyter_on_rails/railtie/jupyter.rake
@@ -5,10 +5,10 @@ namespace :jupyter do
   desc 'start jupyter notebook'
   task :notebook do
     root = Rails.root
-    ipython_dir = ENV['IPYTHONDIR'] || root / '.ipython'
+    ipython_dir = ENV['JUPYTER_DATA_DIR'] || ENV['IPYTHONDIR'] || root / '.ipython'
     ipython_dir = File.absolute_path(ipython_dir.to_s)
 
-    sh "bundle exec iruby register --force --ipython-dir=#{Shellwords.shellescape(ipython_dir.to_s)}"
+    sh "bundle exec iruby register --force JUPYTER_DATA_DIR=#{Shellwords.shellescape(ipython_dir.to_s)}"
 
     sh "rm -rf #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/rails"
     sh "cp -r #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/ruby #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/rails"

--- a/lib/jupyter_on_rails/railtie/jupyter.rake
+++ b/lib/jupyter_on_rails/railtie/jupyter.rake
@@ -22,7 +22,7 @@ namespace :jupyter do
 
     File.write(kernel_file, JSON.dump(kernel_h))
 
-    env = { 'IPYTHONDIR' => ipython_dir.to_s }
+    env = { 'JUPYTER_DATA_DIR' => ipython_dir.to_s }
     commands = %w[jupyter notebook]
     commands = %w[pipenv run] + commands if (root / 'Pipfile').exist?
     Process.exec(env, *commands)


### PR DESCRIPTION
Hi @Yuki-Inoue, thanks for your great work! I really enjoy using it. Here's a fix for a tiny cosmetic issue: When starting the kernel with `rake jupyter:notebook`, we observe a deprecation warning:

```
--ipython-dir is deprecated. Use JUPYTER_DATA_DIR environment variable instead.
```

This PR just follows the hint and makes use of the env variable `JUPYTER_DATA_DIR` instead of the `--ipython-dir` flag. However, passing the env var `IPYTHONDIR` is still working, too. What do you think?

edit: I've seen you've already opened an issue, so this one is tackling #10