### PR TITLE
feat(daru): added activerecord model to_df

### DIFF
--- a/lib/jupyter_on_rails/daru/active_record_ext.rb
+++ b/lib/jupyter_on_rails/daru/active_record_ext.rb
@@ -45,6 +45,10 @@ module JupyterOnRails
           ::Daru::DataFrame.new(datas)
         end
       end
+
+      def to_df
+        ::Daru::DataFrame.new([attributes])
+      end
     end
   end
 end


### PR DESCRIPTION
It is a small feature: To add "to_df" supports single activerecord model to transfer to dataframe