### PR TITLE
Add option to boot kernel in Sandbox mode

### DIFF
--- a/lib/jupyter_on_rails/boot.rb
+++ b/lib/jupyter_on_rails/boot.rb
@@ -1,16 +1,5 @@
 # frozen_string_literal: true
 
-root = ENV.fetch('RAILS_ROOT')
+require 'jupyter_on_rails/kernel'
 
-boot_file = File.expand_path('config/boot.rb', root)
-require boot_file
-
-require_relative 'iruby_kernel_extention'
-JupyterOnRails::IRubyKernelExtention.root = root
-
-require 'iruby'
-module IRuby
-  class Kernel
-    prepend JupyterOnRails::IRubyKernelExtention
-  end
-end
+JupyterOnRails::Kernel.boot

--- a/lib/jupyter_on_rails/boot.rb
+++ b/lib/jupyter_on_rails/boot.rb
@@ -2,4 +2,4 @@
 
 require 'jupyter_on_rails/kernel'
 
-JupyterOnRails::Kernel.boot
+JupyterOnRails::Kernel.new.boot

--- a/lib/jupyter_on_rails/boot_sandbox.rb
+++ b/lib/jupyter_on_rails/boot_sandbox.rb
@@ -1,3 +1,3 @@
 require 'jupyter_on_rails/kernel'
 
-JupyterOnRails::Kernel.boot sandbox: true
+JupyterOnRails::Kernel.new(sandbox: true).boot

--- a/lib/jupyter_on_rails/boot_sandbox.rb
+++ b/lib/jupyter_on_rails/boot_sandbox.rb
@@ -1,0 +1,3 @@
+require 'jupyter_on_rails/kernel'
+
+JupyterOnRails::Kernel.boot sandbox: true

--- a/lib/jupyter_on_rails/iruby_kernel_extention.rb
+++ b/lib/jupyter_on_rails/iruby_kernel_extention.rb
@@ -7,6 +7,23 @@ module JupyterOnRails
     end
 
     def run
+      # Load Daru extensions
+      begin
+        require 'daru'
+        require 'active_record'
+      rescue LoadError
+      else
+        require 'jupyter_on_rails/daru/active_record_ext'
+        require 'jupyter_on_rails/daru/data_frame_ext'
+
+        ::ActiveRecord::Base.instance_eval do
+          include ::JupyterOnRails::Daru::ActiveRecordExt
+        end
+        ::Daru::DataFrame.instance_eval do
+          include ::JupyterOnRails::Daru::DataFrameExt
+        end
+      end
+
       original = Dir.pwd
       root = IRubyKernelExtention.root
       Dir.chdir root

--- a/lib/jupyter_on_rails/iruby_kernel_extention.rb
+++ b/lib/jupyter_on_rails/iruby_kernel_extention.rb
@@ -3,7 +3,7 @@
 module JupyterOnRails
   module IRubyKernelExtention
     class << self
-      attr_accessor :root
+      attr_accessor :root, :sandbox
     end
 
     def run
@@ -14,6 +14,15 @@ module JupyterOnRails
       require app_file
       Rails.application.require_environment!
       Dir.chdir original
+
+      if IRubyKernelExtention.sandbox
+        ActiveRecord::Base.connection.begin_transaction(joinable: false)
+
+        at_exit do
+          ActiveRecord::Base.connection.rollback_transaction
+        end
+      end
+
       super
     end
   end

--- a/lib/jupyter_on_rails/kernel.rb
+++ b/lib/jupyter_on_rails/kernel.rb
@@ -1,17 +1,28 @@
 module JupyterOnRails
-  module Kernel
-    module_function def boot(sandbox: false)
-      root = ENV.fetch('RAILS_ROOT')
+  class Kernel
+    def initialize(sandbox: false)
+      @root = ENV.fetch('RAILS_ROOT')
+      @sandbox = sandbox
+    end
 
-      boot_file = File.expand_path('config/boot.rb', root)
+    def boot
+      boot_rails
+      load_extensions
+    end
+
+    private
+
+    def boot_rails
+      boot_file = File.expand_path('config/boot.rb', @root)
       require boot_file
+    end
 
+    def load_extensions
       require_relative 'iruby_kernel_extention'
-      JupyterOnRails::IRubyKernelExtention.root = root
-      JupyterOnRails::IRubyKernelExtention.sandbox = sandbox
+      JupyterOnRails::IRubyKernelExtention.root = @root
+      JupyterOnRails::IRubyKernelExtention.sandbox = @sandbox
 
       require 'iruby'
-
       IRuby::Kernel.instance_eval { prepend JupyterOnRails::IRubyKernelExtention }
     end
   end

--- a/lib/jupyter_on_rails/kernel.rb
+++ b/lib/jupyter_on_rails/kernel.rb
@@ -1,0 +1,18 @@
+module JupyterOnRails
+  module Kernel
+    module_function def boot(sandbox: false)
+      root = ENV.fetch('RAILS_ROOT')
+
+      boot_file = File.expand_path('config/boot.rb', root)
+      require boot_file
+
+      require_relative 'iruby_kernel_extention'
+      JupyterOnRails::IRubyKernelExtention.root = root
+      JupyterOnRails::IRubyKernelExtention.sandbox = sandbox
+
+      require 'iruby'
+
+      IRuby::Kernel.instance_eval { prepend JupyterOnRails::IRubyKernelExtention }
+    end
+  end
+end

--- a/lib/jupyter_on_rails/railtie.rb
+++ b/lib/jupyter_on_rails/railtie.rb
@@ -8,21 +8,5 @@ module JupyterOnRails
     rake_tasks do
       load 'jupyter_on_rails/railtie/jupyter.rake'
     end
-
-    config.before_configuration do
-      begin
-        require 'daru'
-      rescue LoadError
-      end
-
-      if defined?(::Daru) && defined?(::ActiveRecord)
-        class ::ActiveRecord::Base
-          include ::JupyterOnRails::Daru::ActiveRecordExt
-        end
-        class ::Daru::DataFrame
-          include ::JupyterOnRails::Daru::DataFrameExt
-        end
-      end
-    end
   end
 end

--- a/lib/jupyter_on_rails/railtie/jupyter.rake
+++ b/lib/jupyter_on_rails/railtie/jupyter.rake
@@ -2,6 +2,7 @@
 
 require 'shellwords'
 require 'json'
+require 'ostruct'
 
 namespace :jupyter do
   desc 'start jupyter notebook'
@@ -12,17 +13,23 @@ namespace :jupyter do
 
     sh "JUPYTER_DATA_DIR=#{Shellwords.shellescape(ipython_dir.to_s)} bundle exec iruby register --force"
 
-    sh "rm -rf #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/rails"
-    sh "cp -r #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/ruby #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/rails"
+    [
+      OpenStruct.new(kernel_name: 'rails',         boot_file: '../boot.rb',         name_ext: ''),
+      OpenStruct.new(kernel_name: 'rails-sandbox', boot_file: '../boot_sandbox.rb', name_ext: ', sandbox'),
+    ].each do |cfg|
+      sh "rm -rf #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/#{cfg.kernel_name}"
 
-    kernel_file = File.expand_path('kernels/rails/kernel.json', ipython_dir.to_s)
-    kernel_h = JSON.parse(File.read(kernel_file))
-    kernel_h['argv'] << File.expand_path('../boot.rb', __dir__)
-    kernel_h['display_name'] = "#{Rails.application.class.parent} (rails #{Rails.version})"
-    kernel_h['env'] ||= {}
-    kernel_h['env']['RAILS_ROOT'] = root.to_s
+      sh "cp -r #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/ruby #{Shellwords.shellescape(ipython_dir.to_s)}/kernels/#{cfg.kernel_name}"
 
-    File.write(kernel_file, JSON.dump(kernel_h))
+      kernel_file = File.expand_path("kernels/#{cfg.kernel_name}/kernel.json", ipython_dir.to_s)
+      kernel_h = JSON.parse(File.read(kernel_file))
+      kernel_h['argv'] << File.expand_path(cfg.boot_file, __dir__)
+      kernel_h['display_name'] = "#{Rails.application.class.parent} (rails #{Rails.version}#{cfg.name_ext})"
+      kernel_h['env'] ||= {}
+      kernel_h['env']['RAILS_ROOT'] = root.to_s
+
+      File.write(kernel_file, JSON.dump(kernel_h))
+    end
 
     env = { 'JUPYTER_DATA_DIR' => ipython_dir.to_s }
     commands = %w[jupyter notebook]

--- a/lib/jupyter_on_rails/railtie/jupyter.rake
+++ b/lib/jupyter_on_rails/railtie/jupyter.rake
@@ -6,7 +6,17 @@ require 'ostruct'
 
 namespace :jupyter do
   desc 'start jupyter notebook'
-  task :notebook do
+  task :notebook => :install_kernels do
+    ipython_dir = ENV['IPYTHONDIR'] || Rails.root / '.ipython'
+
+    env = { 'JUPYTER_DATA_DIR' => ipython_dir.to_s }
+    commands = %w[jupyter notebook]
+    commands = %w[pipenv run] + commands if (Rails.root / 'Pipfile').exist?
+    Process.exec(env, *commands)
+  end
+
+  desc 'Install the kernel'
+  task :install_kernels do
     root = Rails.root
     ipython_dir = ENV['JUPYTER_DATA_DIR'] || ENV['IPYTHONDIR'] || root / '.ipython'
     ipython_dir = File.absolute_path(ipython_dir.to_s)
@@ -30,10 +40,5 @@ namespace :jupyter do
 
       File.write(kernel_file, JSON.dump(kernel_h))
     end
-
-    env = { 'JUPYTER_DATA_DIR' => ipython_dir.to_s }
-    commands = %w[jupyter notebook]
-    commands = %w[pipenv run] + commands if (root / 'Pipfile').exist?
-    Process.exec(env, *commands)
   end
 end


### PR DESCRIPTION
I had to move some things around to keep this change DRY, that's why there are so many changes in here.

Another change: `ActiveRecordExt` and `DaruExt` are only loaded in the Kernel, not in the railtie. This allows users to add those gems with `require: false` and avoid loading them in the server process.