### PR TITLE
Rails v8.0 compability

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        ruby-version: 3.3
         bundler-cache: true
     # https://github.com/actions/cache/blob/master/examples.md#ruby---bundler
     - uses: actions/cache@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2.2
         bundler-cache: true
     # https://github.com/actions/cache/blob/master/examples.md#ruby---bundler
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     jupyter_on_rails (0.13.0)
       daru
-      iruby
+      iruby (>= 0.8.1)
       railties
 
 GEM
@@ -95,15 +95,16 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
-    iruby (0.7.4)
+    iruby (0.8.2)
       data_uri (~> 0.1)
       ffi-rzmq
       irb
+      logger
       mime-types (>= 3.3.1)
       multi_json (~> 1.11)
-      native-package-installer
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    logger (1.7.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -115,7 +116,6 @@ GEM
     minitest (5.19.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    native-package-installer (1.1.4)
     nio4r (2.5.7)
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
@@ -188,6 +188,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bump
@@ -197,4 +198,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.2.22
+   2.6.8

--- a/jupyter_on_rails.gemspec
+++ b/jupyter_on_rails.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'iruby'
+  spec.add_dependency 'iruby', '>= 0.8.1'
   spec.add_dependency 'railties'
 
   spec.add_dependency 'daru'

--- a/lib/jupyter_on_rails/initializer.rb
+++ b/lib/jupyter_on_rails/initializer.rb
@@ -61,12 +61,10 @@ module JupyterOnRails
     end
 
     def setup_console_methods
-      require 'rails/console/app'
       IRuby::Kernel
         .instance
         .instance_variable_get(:@backend)
         .instance_variable_get(:@main)
-        .extend(Rails::ConsoleMethods)
     end
 
     def setup_sandbox_transaction


### PR DESCRIPTION
# Rails v8.0 compability

### 📚 Motivation

We observed problems loading our Rails kernels when switching to Rails v8.0.2. The Rails kernels were not loading stating the error `Kernel died: cannot load such file -- rails/console/app`. It turns out that `Rails::ConsoleMethods` are referenced and a quick look to https://github.com/rails/rails/blob/main/railties/lib/rails/console/methods.rb reveals its deprecation.

### ⚙️ What's inside?

* We dropped extending `IRuby::Kernel` by the deprecated module. Also alongside this, we observed it only works when upgrading iruby to v0.8.1.
* Updated GitHub actions config with more recent versions

![Bildschirmfoto 2025-06-06 um 10 46 52](https://github.com/user-attachments/assets/6dd97168-f321-433b-816d-1d183c36e4f5)

It's works good for our specific setup, but I kindly ask @Yuki-Inoue to verify if its compatible with possible other situations that we did not consider 🤔 Let me know if I can extend on this. 